### PR TITLE
Removed lodash from seed dependencies

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,22 +1,20 @@
-const fs = require('fs')
-const path = require('path')
+const {readdir} = require('fs')
+const {join} = require('path')
+const {promisify} = require('util')
 
-module.exports = (app) => {
-  return new Promise((resolve, reject) => {
-    let routesDirPath = path.join(__dirname, 'routes')
+const readdirAsync = promisify(readdir)
 
-    // load all routes to app
-    fs.readdir(routesDirPath, (err, routes) => {
-      if (err) {
-        err.path = routesDirPath
-        reject(err)
-      }
+module.exports = (app) => {  
+  let routesDirPath = join(__dirname, 'routes')
 
-      for (let route of routes) {
-        require(path.join(routesDirPath, route))(app)
-      }
+  try {
+    const routes = readdirAsync(routesDirPath)
 
-      resolve()
-    })
-  })
+    for (let route of routes) {
+      require(path.join(routesDirPath, route))(app)
+    }
+  } catch (err) {
+    err.path = routesDirPath
+    throw err
+  }  
 }

--- a/config/index.js
+++ b/config/index.js
@@ -1,5 +1,4 @@
 require('dotenv').config() // load .env file to `process.env`
-const { merge } = require('lodash')
 const defaultConfig = require('./env/default')
 let environmentConfig
 
@@ -10,7 +9,7 @@ if (['dev', 'development'].indexOf(process.env.NODE_ENV) !== -1) {
   environmentConfig = require('./env/production')
 }
 
-const config = merge(defaultConfig, environmentConfig)
+const config = {...defaultConfig, ...environmentConfig}
 
 config.env = process.env.NODE_ENV
 config.url = `${config.ssl ? 'https' : 'http'}://${config.host}${config.port ? ':' + config.port : ''}`

--- a/config/lib/debugger.js
+++ b/config/lib/debugger.js
@@ -11,7 +11,6 @@
 
 const config = require('@app-config')
 const debug = require('debug')
-const { merge } = require('lodash')
 
 const stubs = {
   logHttpSuccess: () => {},
@@ -30,11 +29,12 @@ let debugFns = {
 }
 
 if (config.debug) {
-  debugFns = merge(debugFns, {
+  debugFns = {
+    ...debugFns, 
     logAppDebug: debug('app:debug'),
     logAppVerbose: debug('app:verbose'),
     logAppInfo: debug('app:info')
-  })
+  }
 
   // set log type colors
   debugFns.logHttpSuccess.color = debug.colors[2] // green

--- a/config/lib/debugger.js
+++ b/config/lib/debugger.js
@@ -45,4 +45,4 @@ if (config.debug) {
   debugFns.logAppInfo.color = debug.colors[0] // cyan
 }
 
-module.exports = merge(stubs, debugFns)
+module.exports = {...stubs, ...debugFns}

--- a/config/lib/logger/index.js
+++ b/config/lib/logger/index.js
@@ -1,6 +1,4 @@
-const path = require('path')
 const config = require('@app-config')
-const { merge } = require('lodash')
 const winston = require('winston')
 const { combine } = winston.format
 const DebugTransport = require('./transports/DebugTransport')
@@ -34,28 +32,31 @@ const customLevels = {
  *      myName: 'person'
  *    })
  */
-const logger = winston.createLogger(merge({
+const logger = winston.createLogger({
   levels: customLevels.levels,
   transports: [
     // for levels `warn` and `error`
-    new (winston.transports.DailyRotateFile)(merge({
+    new (winston.transports.DailyRotateFile)({
       format: combine(
         winston.format.splat(),
         customTimestamp(),
         customFileFormat
-      )
-    }, config.log.rotateFile))
+      ),
+      ...config.log.rotateFile
+    })
   ],
   exceptionHandlers: [
-    new winston.transports.File(merge({
+    new winston.transports.File({
       format: combine(
         winston.format.splat(),
         customTimestamp(),
         customFileFormat
-      )
-    }, config.log.uncaughtExceptionFile))
+      ),
+      ...config.log.uncaughtExceptionFile
+    })
   ],
-}, config.log.options))
+  ...config.log.options
+})
 
 // attach success and fail streams to logger
 require('./streams/morganStreams')(logger)
@@ -63,12 +64,13 @@ require('./streams/morganStreams')(logger)
 // check if we in development mode
 if (['dev', 'development'].indexOf(config.env)) {
   // add debug transport for `success`, `fail`, `debug` and `info`
-  logger.add(new DebugTransport(merge({
+  logger.add(new DebugTransport({
     format: combine(
       winston.format.splat(),
       customDebugFormat
-    )
-  }, config.log.options)))
+    ),
+    ...config.log.options
+  }))
 }
 
 module.exports = logger

--- a/config/lib/utils/parse-error.js
+++ b/config/lib/utils/parse-error.js
@@ -1,6 +1,6 @@
-const path = require('path')
-const { isError } = require('lodash')
 const stringify = require('stringify-object')
+
+const isError = (e) => e instanceof Error
 
 /**
  * Parse error stack and return basic information about error.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "express-session": "^1.15.6",
     "glob": "^7.1.2",
     "helmet": "^3.13.0",
-    "lodash": "^4.17.10",
     "lusca": "^1.6.0",
     "method-override": "^3.0.0",
     "module-alias": "^2.1.0",


### PR DESCRIPTION
__Changes in this PR:__
1. Switched all `lodash.merge` usages to object spreading.
2. Self-implemented `lodash.isError`.
3. Removed `lodash` from the seed dependecies.

While I do love `lodash`, it seems to me that it's really unnecessary here, and does not fit the characteristics of a "seed".  